### PR TITLE
Update sensor status on re-connect

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ DEFAULT_INVERT_RELAY = False
 
 print("GarageQTPi starting")
 discovery_info = {}
+garage_doors = []
 
 # Update the mqtt state topic
 
@@ -51,6 +52,10 @@ def on_connect(client, userdata, flags, rc):
         command_topic = config['command_topic']
         logging.info("Listening for commands on %s" % command_topic)
         client.subscribe(command_topic)
+
+    # Update each door state in case it changed while disconnected.
+    for door in garage_doors:
+        client.publish(door.state_topic, door.state, retain=True)
 
 # Execute the specified command for a door
 
@@ -249,6 +254,11 @@ if __name__ == "__main__":
 
         # Publish initial door state
         client.publish(state_topic, door.state, retain=True)
+
+        # Store Garage Door instance for use on reconnect
+        door.state_topic = state_topic
+        door.command_topic = command_topic
+        garage_doors.append(door)
 
         # If discovery is enabled publish configuration
         if discovery is True:


### PR DESCRIPTION
With the MQTT Availability in use, if the sensor status changes while the network is down, the state is not updated on re-connect. 
So if the Garage is opened while the network is down, when it reconnects, the state in MQTT still indicates that it is closed.
This pull request updates each state in the on_conect().
To do so, I had to save each instance of GarageDoor into an array.  Also had to save the state_topics into those classes to associate it.  Happy to entertain better ways to achieve the same goal... but this at least works.